### PR TITLE
Map optimization

### DIFF
--- a/components/quake_map.py
+++ b/components/quake_map.py
@@ -103,9 +103,12 @@ def get_fault_layer(show_faults=False):
     Keyword arguments:
     show_faults -- A boolean indicating whether to show the faults
     """
-    if not show_faults:
-        return dl.LayerGroup(id='fault-layer', children=[])
+    if show_faults:
+        return fault_layer
+    return dl.LayerGroup(id='fault-layer', children=[])
 
+
+def create_fault_layer():
     blind_faults = shapefile.Reader(faults_blind)
     nonblind_faults = shapefile.Reader(faults_nonblind)
 
@@ -135,3 +138,6 @@ def get_fault_layer(show_faults=False):
     ]
 
     return dl.LayerGroup(id='fault-layer', children=faults)
+
+
+fault_layer = create_fault_layer()

--- a/utils/dataparser.py
+++ b/utils/dataparser.py
@@ -77,6 +77,7 @@ def save_uploaded_data(session_id, data, extension):
     extesions -- File extension of the uploaded file
     """
     cache.delete_memoized(earthquake_data.get_earthquake_data, session_id)
+    cache.delete_memoized(earthquake_data.get_earthquake_data_by_dates)
 
     data.to_json(earthquake_data.TEMP_FILE_DF % session_id)
 

--- a/utils/earthquake_data.py
+++ b/utils/earthquake_data.py
@@ -285,3 +285,9 @@ def get_earthquake_data(session_id):
     except Exception as ex:
         print(os.path.basename(__file__), ':', ex)
         return EarthquakeData('', pd.DataFrame())
+
+
+@cache.memoize(timeout=36000)
+def get_earthquake_data_by_dates(session_id, datemin, datemax):
+    eq_data = get_earthquake_data(session_id)
+    return eq_data.filter_by_dates(datemin, datemax)

--- a/views/quake_map.py
+++ b/views/quake_map.py
@@ -126,7 +126,8 @@ def update_map(slider_value, apply_clicks, session_id, start_date, end_date,
     start_date = get_datetime_from_str(start_date)
     end_date = get_datetime_from_str(end_date)
 
-    eq_data = earthquake_data.get_earthquake_data(session_id)
+    eq_data = earthquake_data.get_earthquake_data_by_dates(
+        session_id, start_date, end_date)
     filtered_data = filter_data(eq_data, start_date, timestep, slider_value)
 
     sizes = get_sizes(


### PR DESCRIPTION
I optimized the map page as much as I could. I timed the code and caching the date range filtering helped a lot. It shaved close to a second from each time the time slider was moved with a large dataset. In theory the app should now work moderately well regardless of the data set size.

However, I noticed that most of the slowness comes from drawing the map in the frontend. Especially with fault lines the map gets very slow. Unfortunately I wasn't able to find a solution because of Dash's limitations (see Trello task for more information). So I think we're going to have to settle for the current solution.