### PR TITLE
Updated WSGI information to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,9 @@ python index.py
 ```
 You can access the app on your browser at http://127.0.0.1:8050
 
-__OR__ Run the production server (Starts Gunicorn):
-```
-chmod +x run.sh
-./run.sh
-```
+## Deployment
+
+In order to deploy the application, you should use a [WSGI](https://en.wikipedia.org/wiki/Web_Server_Gateway_Interface) of your choice, such as [uWSGI](https://uwsgi-docs.readthedocs.io/en/latest/) or [Gunicorn](https://gunicorn.org/). You can follow any instructions for setting up a WSGI framework for Flask (since Dash uses Flask under the hood). The WSGI module can be accessed with `index:server`.
 
 ## Linting
 


### PR DESCRIPTION
The change visible here is just for the readme. 

I also removed the file `/srv/quake/app/wsgi.py` from the seismo server because it was actually not needed and modified the file `/srv/quake/app/quake.ini` accordingly

The full production pipeline works as follows:

1. uWSGI is automatically started by systemd on startup.
      * Configuration file: `/etc/systemd/system/quake.service`
2. uWSGI starts multiple application processes and starts listening to port 8000.
      * Configuration file: `/srv/quake/app/quake.ini`
3. Apache listens to port 80 and forwards all requests to uWSGI running on port 8000.
      * Configuration file: `/etc/httpd/conf/httpd.conf`
4. uWSGI distributes the requests between the application processes.

I added this stuff to the [Trello instructions](https://trello.com/c/NScq363L/56-university-server-instructions) as well. 

I guess there's nothing to test really, maybe that app running on the seismo server still works.