### PR TITLE
Date picker fixes, order-insensitive clustering

### DIFF
--- a/components/cluster.py
+++ b/components/cluster.py
@@ -163,7 +163,7 @@ def callback_wrapper(n_clicks, threshold, start_date, end_date):
         return "Select dates"
     print("Computing clusters...")
     start_date = dt.strptime(start_date,  "%Y-%m-%d")
-    end_date = dt.strptime(end_date,  "%Y-%m-%d")
+    end_date = dt.strptime(end_date,  "%Y-%m-%d") + datetime.timedelta(days=1)
 
     session_id = session.get_session_id()
     data = get_data(session_id)
@@ -193,7 +193,9 @@ def get_figures(edges_np, df, th=1e-5):
     th -- Threshold for computing the weak edges.
    """
     edges = []
-    for e in edges_np[1:]:
+    for e in edges_np:
+        if e[0] == e[1]:
+            continue
         edges.append((e[0], e[1],  {"w": e[2]}))
 
     G = nx.DiGraph()

--- a/components/config/date_picker.py
+++ b/components/config/date_picker.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 import dash_core_components as dcc
 import dash_html_components as html
 
@@ -23,7 +25,7 @@ def get_component(min_date, max_date, default_end_date, id="date-pick"):
         dcc.DatePickerRange(
             id=id,
             min_date_allowed=min_date,
-            max_date_allowed=max_date,
+            max_date_allowed=max_date.date() + timedelta(days=1),
             start_date=start_date,
             end_date=end_date,
             display_format='DD.MM.YYYY'

--- a/components/config/interval_picker.py
+++ b/components/config/interval_picker.py
@@ -6,7 +6,10 @@ def get_component():
     """Return the interval picker component"""
     return html.Div(
         children=[
-            html.Div(className='config-label', children='Update interval for "Play" button'),
+            html.Div(
+                className='config-label',
+                children='Update interval for "Play" button'
+            ),
             dbc.Input(
                 id='interval-seconds', type='number', min=1, step=0.5, value=2
             ),


### PR DESCRIPTION
I noticed that our date picker component doesn't actually allow the `max_date_allowed` date to be picked, only the day before. So I added one day to the max_date